### PR TITLE
Added visual feedback to rotation and thrust

### DIFF
--- a/TheLastShip/Assets/Prefabs/Player/PlayerShip.prefab
+++ b/TheLastShip/Assets/Prefabs/Player/PlayerShip.prefab
@@ -26,7 +26,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 40360095967338024}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.5, z: -6}
+  m_LocalPosition: {x: 0, y: 2, z: -8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 40360096672153371}
@@ -94,6 +94,7 @@ GameObject:
   - component: {fileID: 40360096672153371}
   - component: {fileID: 40360096672153375}
   - component: {fileID: 2338548140980350805}
+  - component: {fileID: 1177640916}
   m_Layer: 0
   m_Name: PlayerShip
   m_TagString: Player
@@ -140,6 +141,8 @@ MonoBehaviour:
   PlayerSecondaryShotPrefab: {fileID: 5246374027109828486, guid: 04cd8b133a155f747b3cb861c9b75423,
     type: 3}
   PlayerShotTransform: {fileID: 6991136550905495391}
+  CurrentTurnDirection: 0
+  CurrentAcceleration: 0
 --- !u!54 &2338548140980350805
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -156,6 +159,29 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 112
   m_CollisionDetection: 0
+--- !u!114 &1177640916
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 40360096672153373}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: faa6d237c18970142aea595dfeb7957c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  PlayerShipModel: {fileID: 1771291064586632576}
+  CameraGameObject: {fileID: 40360095967338024}
+  LookAtTransform: {fileID: 0}
+  modelPosStraight: {x: 0, y: 0, z: 0}
+  modelPosBottom: {x: 0, y: -1, z: 0}
+  modelPosTop: {x: 0, y: 4, z: 0}
+  modelPosLeft: {x: -4, y: 1, z: 0}
+  modelPosRight: {x: 4, y: 1, z: 0}
+  cameraPosCoasting: {x: 0, y: 2, z: -8}
+  cameraPosAccelerating: {x: 0, y: 2, z: -10}
+  cameraPosDecelerating: {x: 0, y: 2, z: -7}
 --- !u!1 &2181552051587281279
 GameObject:
   m_ObjectHideFlags: 0
@@ -255,11 +281,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 40360096672153371}
     m_Modifications:
-    - target: {fileID: -927199367670048503, guid: d7ebc4d935aa91547b13a1b8e327077f,
-        type: 3}
-      propertyPath: m_Name
-      value: PlayerShip_Greybox
-      objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: d7ebc4d935aa91547b13a1b8e327077f,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -268,12 +289,12 @@ PrefabInstance:
     - target: {fileID: -4216859302048453862, guid: d7ebc4d935aa91547b13a1b8e327077f,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.31
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: d7ebc4d935aa91547b13a1b8e327077f,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.57
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: d7ebc4d935aa91547b13a1b8e327077f,
         type: 3}
@@ -330,6 +351,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 15
       objectReference: {fileID: 0}
+    - target: {fileID: -927199367670048503, guid: d7ebc4d935aa91547b13a1b8e327077f,
+        type: 3}
+      propertyPath: m_Name
+      value: PlayerShip_Greybox
+      objectReference: {fileID: 0}
     - target: {fileID: -1496326257652171244, guid: d7ebc4d935aa91547b13a1b8e327077f,
         type: 3}
       propertyPath: m_Convex
@@ -372,6 +398,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d7ebc4d935aa91547b13a1b8e327077f, type: 3}
+--- !u!1 &1771291064586632576 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -927199367670048503, guid: d7ebc4d935aa91547b13a1b8e327077f,
+    type: 3}
+  m_PrefabInstance: {fileID: 7761125753937011849}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &3373119216375074707 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -4216859302048453862, guid: d7ebc4d935aa91547b13a1b8e327077f,

--- a/TheLastShip/Assets/Prefabs/Player/PlayerShip.prefab
+++ b/TheLastShip/Assets/Prefabs/Player/PlayerShip.prefab
@@ -113,7 +113,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 40360095967338037}
-  - {fileID: 6991136550905495391}
   - {fileID: 3373119216375074707}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -180,14 +179,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2181552051587281279}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 3}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.020666668, z: 0.238}
+  m_LocalScale: {x: 0.06666667, y: 0.06666667, z: 0.06666667}
   m_Children:
   - {fileID: 4468777885068429251}
   - {fileID: 4852570104893348063}
-  m_Father: {fileID: 40360096672153371}
-  m_RootOrder: 1
+  m_Father: {fileID: 3373119216375074707}
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4433723190401773323
 GameObject:
@@ -299,7 +298,7 @@ PrefabInstance:
     - target: {fileID: -4216859302048453862, guid: d7ebc4d935aa91547b13a1b8e327077f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: d7ebc4d935aa91547b13a1b8e327077f,
         type: 3}
@@ -331,7 +330,7 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 15
       objectReference: {fileID: 0}
-    - target: {fileID: 8294226038347757094, guid: d7ebc4d935aa91547b13a1b8e327077f,
+    - target: {fileID: -1496326257652171244, guid: d7ebc4d935aa91547b13a1b8e327077f,
         type: 3}
       propertyPath: m_Convex
       value: 1
@@ -341,17 +340,12 @@ PrefabInstance:
       propertyPath: m_Convex
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2180280896181515486, guid: d7ebc4d935aa91547b13a1b8e327077f,
+    - target: {fileID: -462564169340971635, guid: d7ebc4d935aa91547b13a1b8e327077f,
         type: 3}
       propertyPath: m_Convex
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: -5648161683495120068, guid: d7ebc4d935aa91547b13a1b8e327077f,
-        type: 3}
-      propertyPath: m_Convex
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -1496326257652171244, guid: d7ebc4d935aa91547b13a1b8e327077f,
+    - target: {fileID: 8294226038347757094, guid: d7ebc4d935aa91547b13a1b8e327077f,
         type: 3}
       propertyPath: m_Convex
       value: 1
@@ -361,12 +355,17 @@ PrefabInstance:
       propertyPath: m_Convex
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: -462564169340971635, guid: d7ebc4d935aa91547b13a1b8e327077f,
+    - target: {fileID: -5648161683495120068, guid: d7ebc4d935aa91547b13a1b8e327077f,
         type: 3}
       propertyPath: m_Convex
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 703981115517489317, guid: d7ebc4d935aa91547b13a1b8e327077f,
+        type: 3}
+      propertyPath: m_Convex
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2180280896181515486, guid: d7ebc4d935aa91547b13a1b8e327077f,
         type: 3}
       propertyPath: m_Convex
       value: 1

--- a/TheLastShip/Assets/Prefabs/Projectiles/PlayerSecondaryShot.prefab
+++ b/TheLastShip/Assets/Prefabs/Projectiles/PlayerSecondaryShot.prefab
@@ -121,9 +121,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 29f7e68f7f0828e4da9280bb72fa1c35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ShotSpeed: 150
+  ShotSpeed: 250
   DespawnTime: 8
   UnchargedShotDamage: 3
   ChargedShotDamage: 10
   Fired: 0
-  Charged: 0
+  FullyCharged: 0
+  ReadyToFire: 0

--- a/TheLastShip/Assets/Prefabs/Projectiles/PlayerShot.prefab
+++ b/TheLastShip/Assets/Prefabs/Projectiles/PlayerShot.prefab
@@ -122,5 +122,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4fcc1d95727d8974cb56abcfe62da0ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ShotSpeed: 200
+  ShotSpeed: 500
   DespawnTime: 5
+  BasicShotDamage: 1

--- a/TheLastShip/Assets/Prefabs/UI/InGameCanvas.prefab
+++ b/TheLastShip/Assets/Prefabs/UI/InGameCanvas.prefab
@@ -358,6 +358,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1942082754551752374}
+  - {fileID: 515356130873729625}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -571,6 +572,80 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
+--- !u!1 &5853125578782904587
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 515356130873729625}
+  - component: {fileID: 3161942798929438087}
+  - component: {fileID: 2454740887788637541}
+  m_Layer: 5
+  m_Name: Crosshair
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &515356130873729625
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5853125578782904587}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1185773637663114057}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3161942798929438087
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5853125578782904587}
+  m_CullTransparentMesh: 0
+--- !u!114 &2454740887788637541
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5853125578782904587}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 844484899428d2c44a0c8718852829ac, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!1 &8643501286575436033
 GameObject:
   m_ObjectHideFlags: 0
@@ -730,12 +805,12 @@ PrefabInstance:
     - target: {fileID: 598179829923266407, guid: cbda76fe3465735449fad81c5a26f3fc,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -120
+      value: -360
       objectReference: {fileID: 0}
     - target: {fileID: 598179829923266407, guid: cbda76fe3465735449fad81c5a26f3fc,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: -60
+      value: -360
       objectReference: {fileID: 0}
     - target: {fileID: 598179829923266407, guid: cbda76fe3465735449fad81c5a26f3fc,
         type: 3}
@@ -869,18 +944,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cbda76fe3465735449fad81c5a26f3fc, type: 3}
---- !u!224 &1942082754551752374 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 598179829923266407, guid: cbda76fe3465735449fad81c5a26f3fc,
-    type: 3}
-  m_PrefabInstance: {fileID: 1350658341853534673}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &4261404954134200221 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2998567913119229516, guid: cbda76fe3465735449fad81c5a26f3fc,
-    type: 3}
-  m_PrefabInstance: {fileID: 1350658341853534673}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1820086691751047772 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 863775960668154765, guid: cbda76fe3465735449fad81c5a26f3fc,
@@ -911,3 +974,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7bf6727c2fc53f4aaf7d0821bd1d34f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &1942082754551752374 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 598179829923266407, guid: cbda76fe3465735449fad81c5a26f3fc,
+    type: 3}
+  m_PrefabInstance: {fileID: 1350658341853534673}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4261404954134200221 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2998567913119229516, guid: cbda76fe3465735449fad81c5a26f3fc,
+    type: 3}
+  m_PrefabInstance: {fileID: 1350658341853534673}
+  m_PrefabAsset: {fileID: 0}

--- a/TheLastShip/Assets/Prefabs/UI/InGameCanvas.prefab
+++ b/TheLastShip/Assets/Prefabs/UI/InGameCanvas.prefab
@@ -357,8 +357,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 1942082754551752374}
   - {fileID: 515356130873729625}
+  - {fileID: 1942082754551752374}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -602,7 +602,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1185773637663114057}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -732,6 +732,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1185773637663114057}
     m_Modifications:
+    - target: {fileID: 201032835127020320, guid: cbda76fe3465735449fad81c5a26f3fc,
+        type: 3}
+      propertyPath: classicControlsButton
+      value: 
+      objectReference: {fileID: 1820086691751047772}
+    - target: {fileID: 201032835127020320, guid: cbda76fe3465735449fad81c5a26f3fc,
+        type: 3}
+      propertyPath: invertYLookToggle
+      value: 
+      objectReference: {fileID: 611469079}
     - target: {fileID: 2998567913119229516, guid: cbda76fe3465735449fad81c5a26f3fc,
         type: 3}
       propertyPath: m_Name
@@ -775,7 +785,7 @@ PrefabInstance:
     - target: {fileID: 598179829923266407, guid: cbda76fe3465735449fad81c5a26f3fc,
         type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 598179829923266407, guid: cbda76fe3465735449fad81c5a26f3fc,
         type: 3}
@@ -842,16 +852,6 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 201032835127020320, guid: cbda76fe3465735449fad81c5a26f3fc,
-        type: 3}
-      propertyPath: classicControlsButton
-      value: 
-      objectReference: {fileID: 1820086691751047772}
-    - target: {fileID: 201032835127020320, guid: cbda76fe3465735449fad81c5a26f3fc,
-        type: 3}
-      propertyPath: invertYLookToggle
-      value: 
-      objectReference: {fileID: 611469079}
     - target: {fileID: 863775960668154765, guid: cbda76fe3465735449fad81c5a26f3fc,
         type: 3}
       propertyPath: m_Colors.m_HighlightedColor.r

--- a/TheLastShip/Assets/Scenes/Test Scenes/LukeControlsTest.unity
+++ b/TheLastShip/Assets/Scenes/Test Scenes/LukeControlsTest.unity
@@ -278,26 +278,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!1 &1177640915 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 40360096672153373, guid: afae1227a7c392d4fbfaecdbc7978071,
-    type: 3}
-  m_PrefabInstance: {fileID: 40360096028858181}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1177640916
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1177640915}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: faa6d237c18970142aea595dfeb7957c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  PlayerShipModel: {fileID: 1625536805}
-  PlayerShipTargetLocation: {x: 0, y: 0, z: 0}
 --- !u!1 &1556379175
 GameObject:
   m_ObjectHideFlags: 0
@@ -389,12 +369,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1 &1625536805 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1771291064586632576, guid: afae1227a7c392d4fbfaecdbc7978071,
-    type: 3}
-  m_PrefabInstance: {fileID: 40360096028858181}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2122161280
 GameObject:
   m_ObjectHideFlags: 0
@@ -553,6 +527,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1177640916, guid: afae1227a7c392d4fbfaecdbc7978071, type: 3}
+      propertyPath: modelPosLeft.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1177640916, guid: afae1227a7c392d4fbfaecdbc7978071, type: 3}
+      propertyPath: modelPosRight.y
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: afae1227a7c392d4fbfaecdbc7978071, type: 3}
 --- !u!1001 &1185773638368269004
@@ -671,6 +653,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Pivot.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 515356130873729625, guid: d77aa472b738c0743925ba919c0bd2c2,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d77aa472b738c0743925ba919c0bd2c2, type: 3}

--- a/TheLastShip/Assets/Scenes/Test Scenes/LukeControlsTest.unity
+++ b/TheLastShip/Assets/Scenes/Test Scenes/LukeControlsTest.unity
@@ -278,6 +278,26 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!1 &1177640915 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 40360096672153373, guid: afae1227a7c392d4fbfaecdbc7978071,
+    type: 3}
+  m_PrefabInstance: {fileID: 40360096028858181}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1177640916
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1177640915}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: faa6d237c18970142aea595dfeb7957c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  PlayerShipModel: {fileID: 1625536805}
+  PlayerShipTargetLocation: {x: 0, y: 0, z: 0}
 --- !u!1 &1556379175
 GameObject:
   m_ObjectHideFlags: 0
@@ -369,6 +389,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1625536805 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1771291064586632576, guid: afae1227a7c392d4fbfaecdbc7978071,
+    type: 3}
+  m_PrefabInstance: {fileID: 40360096028858181}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2122161280
 GameObject:
   m_ObjectHideFlags: 0
@@ -645,26 +671,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Pivot.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1942082754551752374, guid: d77aa472b738c0743925ba919c0bd2c2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1942082754551752374, guid: d77aa472b738c0743925ba919c0bd2c2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: -360
-      objectReference: {fileID: 0}
-    - target: {fileID: 1942082754551752374, guid: d77aa472b738c0743925ba919c0bd2c2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1942082754551752374, guid: d77aa472b738c0743925ba919c0bd2c2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: -360
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d77aa472b738c0743925ba919c0bd2c2, type: 3}

--- a/TheLastShip/Assets/Scripts/GameSettings.cs
+++ b/TheLastShip/Assets/Scripts/GameSettings.cs
@@ -14,4 +14,6 @@ public static class GameSettings
     public static ControlScheme CurrentControlScheme = ControlScheme.classic;
 
     public static bool InvertYLook;
+
+    public static bool IsPaused;
 }

--- a/TheLastShip/Assets/Scripts/Player/PlayerShipMovement.cs
+++ b/TheLastShip/Assets/Scripts/Player/PlayerShipMovement.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// This script controls the movement of the player ship in reaction to actions taken by the player.
+/// Actions include movement based on turning and thrust.
+/// </summary>
+public class PlayerShipMovement : MonoBehaviour
+{
+    [SerializeField, Tooltip("The player ship model.")]
+    public GameObject PlayerShipModel;
+
+    private PlayerController pCont;
+
+    [HideInInspector]
+    public Vector3 PlayerShipTargetLocation;
+
+    private Vector3 prevRotation; // The rotation of the ship on the previous frame
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        pCont = this.gameObject.GetComponent<PlayerController>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        this.gameObject.transform.position = Vector3.Lerp(this.gameObject.transform.position, PlayerShipTargetLocation, 0.4f);
+
+        if (this.gameObject.transform.rotation.eulerAngles.y < prevRotation.y)
+        {
+
+        }
+
+        // Set previous rotation at the end of the current step.
+        prevRotation = this.gameObject.transform.rotation.eulerAngles;
+    }
+}

--- a/TheLastShip/Assets/Scripts/Player/PlayerShipMovement.cs
+++ b/TheLastShip/Assets/Scripts/Player/PlayerShipMovement.cs
@@ -11,12 +11,36 @@ public class PlayerShipMovement : MonoBehaviour
     [SerializeField, Tooltip("The player ship model.")]
     public GameObject PlayerShipModel;
 
+    [SerializeField, Tooltip("The camera GameObject.")]
+    public GameObject CameraGameObject;
+
+    [SerializeField, Tooltip("The position of the ship model when moving straight.")]
+    private Vector3 modelPosStraight;
+    [SerializeField, Tooltip("The position of the ship model when turning upwards.")]
+    private Vector3 modelPosBottom;
+    [SerializeField, Tooltip("The position of the ship model when turning downwards.")]
+    private Vector3 modelPosTop;
+    [SerializeField, Tooltip("The position of the ship model when turning right.")]
+    private Vector3 modelPosLeft;
+    [SerializeField, Tooltip("The position of the ship model when turning left.")]
+    private Vector3 modelPosRight;
+
+    [SerializeField, Tooltip("The position of the camera when maintaining a constant speed.")]
+    private Vector3 cameraPosCoasting;
+    [SerializeField, Tooltip("The position of the camera when accelerating.")]
+    private Vector3 cameraPosAccelerating;
+    [SerializeField, Tooltip("The position of the camera when decelerating.")]
+    private Vector3 cameraPosDecelerating;
+
     private PlayerController pCont;
 
-    [HideInInspector]
-    public Vector3 PlayerShipTargetLocation;
+    private PlayerController.TurnDirection currentTurnDir;
 
-    private Vector3 prevRotation; // The rotation of the ship on the previous frame
+    private PlayerController.AccelerationState currentAccel;
+
+    private Vector3 PlayerShipTargetLocation;
+
+    private Vector3 CameraTargetLocation;
 
     // Start is called before the first frame update
     void Start()
@@ -27,14 +51,56 @@ public class PlayerShipMovement : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        this.gameObject.transform.position = Vector3.Lerp(this.gameObject.transform.position, PlayerShipTargetLocation, 0.4f);
+        currentTurnDir = pCont.CurrentTurnDirection; // Update turn direction
 
-        if (this.gameObject.transform.rotation.eulerAngles.y < prevRotation.y)
+        currentAccel = pCont.CurrentAcceleration; // Update acceleration
+
+        UpdatePlayerShipLocation();
+
+        UpdateCameraLocation();
+    }
+
+    private void UpdatePlayerShipLocation()
+    {
+        if (!GameSettings.IsPaused)
+            PlayerShipModel.transform.localPosition = Vector3.Slerp(PlayerShipModel.transform.localPosition, PlayerShipTargetLocation, 0.02f);
+
+        switch (currentTurnDir)
         {
-
+            case PlayerController.TurnDirection.down:
+                PlayerShipTargetLocation = modelPosTop;
+                break;
+            case PlayerController.TurnDirection.up:
+                PlayerShipTargetLocation = modelPosBottom;
+                break;
+            case PlayerController.TurnDirection.right:
+                PlayerShipTargetLocation = modelPosLeft;
+                break;
+            case PlayerController.TurnDirection.left:
+                PlayerShipTargetLocation = modelPosRight;
+                break;
+            case PlayerController.TurnDirection.none:
+                PlayerShipTargetLocation = modelPosStraight;
+                break;
         }
+    }
 
-        // Set previous rotation at the end of the current step.
-        prevRotation = this.gameObject.transform.rotation.eulerAngles;
+    private void UpdateCameraLocation()
+    {
+        if (!GameSettings.IsPaused)
+            CameraGameObject.transform.localPosition = Vector3.Lerp(CameraGameObject.transform.localPosition, CameraTargetLocation, 0.08f);
+
+        switch (currentAccel)
+        {
+            case PlayerController.AccelerationState.accelerating:
+                CameraTargetLocation = cameraPosAccelerating;
+                break;
+            case PlayerController.AccelerationState.coasting:
+                CameraTargetLocation = cameraPosCoasting;
+                break;
+            case PlayerController.AccelerationState.decelerating:
+                CameraTargetLocation = cameraPosDecelerating;
+                break;
+        }
     }
 }

--- a/TheLastShip/Assets/Scripts/Player/PlayerShipMovement.cs.meta
+++ b/TheLastShip/Assets/Scripts/Player/PlayerShipMovement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: faa6d237c18970142aea595dfeb7957c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TheLastShip/Assets/Scripts/UI/PauseMenuFunctions.cs
+++ b/TheLastShip/Assets/Scripts/UI/PauseMenuFunctions.cs
@@ -17,6 +17,8 @@ public class PauseMenuFunctions : MonoBehaviour
         {
             Time.timeScale = 1f;
 
+            GameSettings.IsPaused = false;
+
             this.gameObject.SetActive(false);
         }
     }
@@ -24,6 +26,8 @@ public class PauseMenuFunctions : MonoBehaviour
     private void OnEnable()
     {
         Time.timeScale = 0f;
+
+        GameSettings.IsPaused = true;
 
         classicControlsButton.Select();
     }

--- a/TheLastShip/TheLastShip.sln
+++ b/TheLastShip/TheLastShip.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Assembly-CSharp", "Assembly-CSharp.csproj", "{1E9B1519-8164-17EA-55FF-B2CC2734A1F8}"
 EndProject
 Global


### PR DESCRIPTION
- The script PlayerShipMovement.cs moves the player ship around in the view, giving visual feedback to turning and accelerating.
- Enums added to PlayerController.cs keep track of rotation direction and acceleration, providing context to PlayerShipMovement.cs.
- Primary projectile speed increased to 500 from 200.
- Secondary projectile speed increased to 250 from 150.